### PR TITLE
Resolve lint issues and configure Biome for Tailwind

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -20,12 +20,15 @@
 		"indentStyle": "tab"
 	},
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true
-		}
-	},
+        "linter": {
+                "enabled": true,
+                "rules": {
+                        "recommended": true,
+                        "suspicious": {
+                                "noUnknownAtRules": "off"
+                        }
+                }
+        },
 	"javascript": {
 		"formatter": {
 			"quoteStyle": "double"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,6 +22,7 @@ export default function Header() {
     <>
       <header className="p-4 flex items-center bg-gray-800 text-white shadow-lg">
         <button
+          type="button"
           onClick={() => setIsOpen(true)}
           className="p-2 hover:bg-gray-700 rounded-lg transition-colors"
           aria-label="Open menu"
@@ -47,6 +48,7 @@ export default function Header() {
         <div className="flex items-center justify-between p-4 border-b border-gray-700">
           <h2 className="text-xl font-bold">Navigation</h2>
           <button
+            type="button"
             onClick={() => setIsOpen(false)}
             className="p-2 hover:bg-gray-800 rounded-lg transition-colors"
             aria-label="Close menu"
@@ -111,6 +113,7 @@ export default function Header() {
               <span className="font-medium">Start - SSR Demos</span>
             </Link>
             <button
+              type="button"
               className="p-2 hover:bg-gray-800 rounded-lg transition-colors"
               onClick={() =>
                 setGroupedExpanded((prev) => ({

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,7 +1,4 @@
 import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router'
-import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
-import { TanStackDevtools } from '@tanstack/react-devtools'
-
 import appCss from '../styles.css?url'
 
 export const Route = createRootRoute({
@@ -37,17 +34,6 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       </head>
       <body>
         {children}
-        {/* <TanStackDevtools
-          config={{
-            position: 'bottom-right',
-          }}
-          plugins={[
-            {
-              name: 'Tanstack Router',
-              render: <TanStackRouterDevtoolsPanel />,
-            },
-          ]}
-        /> */}
         <Scripts />
       </body>
     </html>

--- a/src/routes/blog/$slug.tsx
+++ b/src/routes/blog/$slug.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute, Link, notFound } from '@tanstack/react-router'
-import { formatDate, type BlogPost } from '@/lib/blog'
+import { formatDate } from '@/lib/blog'
 import { getPostBySlug } from '@/lib/blog.server'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
 export const Route = createFileRoute('/blog/$slug')({
-  component: BlogPost,
+  component: BlogPostPage,
   loader: async ({ params }) => {
     const post = await getPostBySlug(params.slug)
     if (!post) {
@@ -26,7 +26,7 @@ export const Route = createFileRoute('/blog/$slug')({
   }),
 })
 
-function BlogPost() {
+function BlogPostPage() {
   const { post } = Route.useLoaderData()
 
   return (


### PR DESCRIPTION
## Summary
- add explicit `type="button"` attributes to header controls to satisfy accessibility linting
- configure Biome to allow Tailwind-specific at-rules and remove unused devtools imports
- rename the blog post route component to avoid redeclaration conflicts

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68f172532cfc83299ce341292d74aa5d