### PR TITLE
Fix blog markdown glob raw import

### DIFF
--- a/src/lib/blog.server.ts
+++ b/src/lib/blog.server.ts
@@ -56,10 +56,11 @@ async function loadPosts(): Promise<LoadedPost[]> {
   }
 
   // Dynamically import all markdown files from src/content/blog
-  // Using eager: true and as: 'raw' to get the raw content directly
-  const modules = import.meta.glob('/src/content/blog/*.md', {
+  // Using eager: true with the raw query to get the file contents directly
+  const modules = import.meta.glob('../content/blog/*.md', {
     eager: true,
-    as: 'raw',
+    query: '?raw',
+    import: 'default',
   }) as Record<string, string>
 
   const posts: LoadedPost[] = []


### PR DESCRIPTION
## Summary
- update the blog markdown glob to use the query-based raw import configuration so Vite includes markdown in client builds
- refresh the loader comment to match the new import settings

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68f217aca8e083299015961aaf1fca0c