### PR TITLE
Add /photos gallery route with server-side auth, blurred previews, and slideshow

### DIFF
--- a/src/lib/photos.server.ts
+++ b/src/lib/photos.server.ts
@@ -1,0 +1,364 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+
+const PHOTO_LIBRARY_PASSWORD =
+  process.env.PHOTO_LIBRARY_PASSWORD ?? "letmein";
+const PHOTO_LIBRARY_SECRET =
+  process.env.PHOTO_LIBRARY_SECRET ?? "development-only-secret";
+
+export const PHOTO_SESSION_COOKIE = "photo_session";
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;
+
+export type Photo = {
+  id: string;
+  alt: string;
+  src: string;
+  blurred: boolean;
+};
+
+export type PhotoAlbum = {
+  id: string;
+  title: string;
+  date: string;
+  description?: string;
+  coverSrc: string;
+  coverBlurred: boolean;
+  photoCount: number;
+  photos: Photo[];
+};
+
+export type PhotoCategory = {
+  id: string;
+  title: string;
+  description?: string;
+  albums: PhotoAlbum[];
+};
+
+type RawPhoto = {
+  id: string;
+  alt: string;
+  fullSrc: string;
+  blurSrc: string;
+};
+
+type RawAlbum = {
+  id: string;
+  title: string;
+  date: string;
+  description?: string;
+  coverPhotoId: string;
+  photos: RawPhoto[];
+};
+
+type RawCategory = {
+  id: string;
+  title: string;
+  description?: string;
+  albums: RawAlbum[];
+};
+
+const PHOTO_LIBRARY: RawCategory[] = [
+  {
+    id: "trips",
+    title: "Trips",
+    description: "Road miles, mountain air, and long golden hours.",
+    albums: [
+      {
+        id: "dolomites-2024",
+        title: "Dolomites – Autumn 2024",
+        date: "2024-10-12",
+        description: "Soft morning haze, jagged peaks, espresso stops.",
+        coverPhotoId: "dolomites-1",
+        photos: [
+          {
+            id: "dolomites-1",
+            alt: "Sunrise over alpine peaks",
+            fullSrc:
+              "https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1600&q=85",
+            blurSrc:
+              "https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=120&q=20",
+          },
+          {
+            id: "dolomites-2",
+            alt: "Mountain ridge with low clouds",
+            fullSrc:
+              "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=85",
+            blurSrc:
+              "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=120&q=20",
+          },
+          {
+            id: "dolomites-3",
+            alt: "Trail winding through wildflowers",
+            fullSrc:
+              "https://images.unsplash.com/photo-1470770841072-f978cf4d019e?auto=format&fit=crop&w=1600&q=85",
+            blurSrc:
+              "https://images.unsplash.com/photo-1470770841072-f978cf4d019e?auto=format&fit=crop&w=120&q=20",
+          },
+          {
+            id: "dolomites-4",
+            alt: "Cabin near rocky cliffs",
+            fullSrc:
+              "https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=1600&q=85",
+            blurSrc:
+              "https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=120&q=20",
+          },
+          {
+            id: "dolomites-5",
+            alt: "Golden hour valley light",
+            fullSrc:
+              "https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=1600&q=85",
+            blurSrc:
+              "https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=120&q=20",
+          },
+        ],
+      },
+      {
+        id: "lisbon-2023",
+        title: "Lisbon – Summer 2023",
+        date: "2023-07-09",
+        description: "Azulejos, tram rides, and late-night pastel de nata.",
+        coverPhotoId: "lisbon-1",
+        photos: [
+          {
+            id: "lisbon-1",
+            alt: "Pastel buildings in Lisbon",
+            fullSrc:
+              "https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=1600&q=80",
+            blurSrc:
+              "https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=120&q=20",
+          },
+          {
+            id: "lisbon-2",
+            alt: "Tram on a hillside",
+            fullSrc:
+              "https://images.unsplash.com/photo-1470770903676-69b98201ea1c?auto=format&fit=crop&w=1600&q=80",
+            blurSrc:
+              "https://images.unsplash.com/photo-1470770903676-69b98201ea1c?auto=format&fit=crop&w=120&q=20",
+          },
+          {
+            id: "lisbon-3",
+            alt: "Sunset over the river",
+            fullSrc:
+              "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80",
+            blurSrc:
+              "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=120&q=20",
+          },
+          {
+            id: "lisbon-4",
+            alt: "Cafe table with espresso",
+            fullSrc:
+              "https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=1600&q=80",
+            blurSrc:
+              "https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=120&q=20",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "everyday",
+    title: "Everyday",
+    description: "Quiet moments, daily rituals, and familiar rooms.",
+    albums: [
+      {
+        id: "weekend-light",
+        title: "Weekend Light",
+        date: "2024-03-02",
+        description: "Soft interiors and slow morning light.",
+        coverPhotoId: "weekend-1",
+        photos: [
+          {
+            id: "weekend-1",
+            alt: "Sunlit desk with coffee",
+            fullSrc:
+              "https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1600&q=85",
+            blurSrc:
+              "https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=120&q=20",
+          },
+          {
+            id: "weekend-2",
+            alt: "Plant by the window",
+            fullSrc:
+              "https://images.unsplash.com/photo-1454165804606-c3d57bc86b40?auto=format&fit=crop&w=1600&q=85",
+            blurSrc:
+              "https://images.unsplash.com/photo-1454165804606-c3d57bc86b40?auto=format&fit=crop&w=120&q=20",
+          },
+          {
+            id: "weekend-3",
+            alt: "Notebook with handwritten notes",
+            fullSrc:
+              "https://images.unsplash.com/photo-1488998427799-e3362cec87c3?auto=format&fit=crop&w=1600&q=85",
+            blurSrc:
+              "https://images.unsplash.com/photo-1488998427799-e3362cec87c3?auto=format&fit=crop&w=120&q=20",
+          },
+          {
+            id: "weekend-4",
+            alt: "Vinyl record spinning",
+            fullSrc:
+              "https://images.unsplash.com/photo-1511379938547-c1f69419868d?auto=format&fit=crop&w=1600&q=85",
+            blurSrc:
+              "https://images.unsplash.com/photo-1511379938547-c1f69419868d?auto=format&fit=crop&w=120&q=20",
+          },
+          {
+            id: "weekend-5",
+            alt: "Open book on a blanket",
+            fullSrc:
+              "https://images.unsplash.com/photo-1455885666463-18f7d8a3692c?auto=format&fit=crop&w=1600&q=85",
+            blurSrc:
+              "https://images.unsplash.com/photo-1455885666463-18f7d8a3692c?auto=format&fit=crop&w=120&q=20",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const getPhotoLibrary = createServerFn({ method: "GET" }).handler(
+  ({ request }) => {
+    const isAuthenticated = hasValidSession(request);
+    return {
+      isAuthenticated,
+      sessionMaxAgeSeconds: SESSION_MAX_AGE_SECONDS,
+      categories: PHOTO_LIBRARY.map((category) =>
+        mapCategory(category, isAuthenticated),
+      ),
+    };
+  },
+);
+
+export const loginToPhotoLibrary = createServerFn({ method: "POST" })
+  .inputValidator(z.object({ password: z.string().min(1) }))
+  .handler(({ data }) => {
+    if (data.password !== PHOTO_LIBRARY_PASSWORD) {
+      return {
+        ok: false,
+        message: "Incorrect password.",
+      } as const;
+    }
+
+    return {
+      ok: true,
+      token: createSessionToken(),
+      maxAgeSeconds: SESSION_MAX_AGE_SECONDS,
+    } as const;
+  });
+
+export const logoutFromPhotoLibrary = createServerFn({ method: "POST" }).handler(
+  () => {
+    return {
+      ok: true,
+    } as const;
+  },
+);
+
+function mapCategory(category: RawCategory, isAuthenticated: boolean): PhotoCategory {
+  return {
+    id: category.id,
+    title: category.title,
+    description: category.description,
+    albums: category.albums.map((album) => mapAlbum(album, isAuthenticated)),
+  };
+}
+
+function mapAlbum(album: RawAlbum, isAuthenticated: boolean): PhotoAlbum {
+  const coverPhoto = album.photos.find(
+    (photo) => photo.id === album.coverPhotoId,
+  );
+  const cover = coverPhoto ?? album.photos[0];
+  const coverSrc = isAuthenticated ? cover.fullSrc : cover.blurSrc;
+
+  return {
+    id: album.id,
+    title: album.title,
+    date: album.date,
+    description: album.description,
+    coverSrc,
+    coverBlurred: !isAuthenticated,
+    photoCount: album.photos.length,
+    photos: album.photos.map((photo) => ({
+      id: photo.id,
+      alt: photo.alt,
+      src: isAuthenticated ? photo.fullSrc : photo.blurSrc,
+      blurred: !isAuthenticated,
+    })),
+  };
+}
+
+function hasValidSession(request: Request): boolean {
+  const cookieHeader = request.headers.get("cookie") ?? "";
+  const cookies = parseCookies(cookieHeader);
+  const token = cookies[PHOTO_SESSION_COOKIE];
+
+  if (!token) {
+    return false;
+  }
+
+  return verifySessionToken(token);
+}
+
+function parseCookies(cookieHeader: string): Record<string, string> {
+  return cookieHeader
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .filter(Boolean)
+    .reduce<Record<string, string>>((acc, cookie) => {
+      const [key, ...valueParts] = cookie.split("=");
+      if (!key) {
+        return acc;
+      }
+      acc[key] = decodeURIComponent(valueParts.join("="));
+      return acc;
+    }, {});
+}
+
+function createSessionToken(): string {
+  const issuedAt = Date.now();
+  const payload = {
+    iat: issuedAt,
+    exp: issuedAt + SESSION_MAX_AGE_SECONDS * 1000,
+  };
+  const payloadBase64 = Buffer.from(JSON.stringify(payload)).toString(
+    "base64url",
+  );
+  const signature = createSignature(payloadBase64);
+
+  return `${payloadBase64}.${signature}`;
+}
+
+function verifySessionToken(token: string): boolean {
+  const [payloadBase64, signature] = token.split(".");
+  if (!payloadBase64 || !signature) {
+    return false;
+  }
+
+  const expectedSignature = createSignature(payloadBase64);
+  if (
+    signature.length !== expectedSignature.length ||
+    !timingSafeEqual(
+      Buffer.from(signature),
+      Buffer.from(expectedSignature),
+    )
+  ) {
+    return false;
+  }
+
+  try {
+    const payload = JSON.parse(
+      Buffer.from(payloadBase64, "base64url").toString("utf-8"),
+    ) as { exp?: number };
+    if (!payload.exp) {
+      return false;
+    }
+
+    return Date.now() <= payload.exp;
+  } catch {
+    return false;
+  }
+}
+
+function createSignature(payloadBase64: string): string {
+  return createHmac("sha256", PHOTO_LIBRARY_SECRET)
+    .update(payloadBase64)
+    .digest("base64url");
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,12 +10,18 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as PhotosIndexRouteImport } from './routes/photos/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PhotosIndexRoute = PhotosIndexRouteImport.update({
+  id: '/photos/',
+  path: '/photos/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BlogIndexRoute = BlogIndexRouteImport.update({
@@ -33,30 +39,34 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/blog': typeof BlogIndexRoute
+  '/photos': typeof PhotosIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/blog': typeof BlogIndexRoute
+  '/photos': typeof PhotosIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/blog/': typeof BlogIndexRoute
+  '/photos/': typeof PhotosIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/blog/$slug' | '/blog'
+  fullPaths: '/' | '/blog/$slug' | '/blog' | '/photos'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/blog/$slug' | '/blog'
-  id: '__root__' | '/' | '/blog/$slug' | '/blog/'
+  to: '/' | '/blog/$slug' | '/blog' | '/photos'
+  id: '__root__' | '/' | '/blog/$slug' | '/blog/' | '/photos/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   BlogSlugRoute: typeof BlogSlugRoute
   BlogIndexRoute: typeof BlogIndexRoute
+  PhotosIndexRoute: typeof PhotosIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -66,6 +76,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/photos/': {
+      id: '/photos/'
+      path: '/photos'
+      fullPath: '/photos'
+      preLoaderRoute: typeof PhotosIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/blog/': {
@@ -89,6 +106,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   BlogSlugRoute: BlogSlugRoute,
   BlogIndexRoute: BlogIndexRoute,
+  PhotosIndexRoute: PhotosIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/photos/index.tsx
+++ b/src/routes/photos/index.tsx
@@ -155,16 +155,14 @@ function PhotosPage() {
           <div>
             <Link
               to="/"
-              className="text-sm font-semibold uppercase tracking-widest text-neutral-400"
+              className="text-xs font-semibold uppercase tracking-[0.35em] text-neutral-400"
             >
               isak.dev
             </Link>
-            <h1 className="mt-2 text-3xl font-semibold lowercase tracking-tight">
+            <h1 className="mt-3 text-3xl font-semibold lowercase tracking-tight">
               photos
             </h1>
-            <p className="mt-1 text-sm text-neutral-500">
-              Private photo library. Public visitors only see blurred previews.
-            </p>
+            <div className="mt-3 h-px w-16 bg-neutral-200" />
           </div>
 
           <div className="w-full md:w-auto">
@@ -300,7 +298,7 @@ function PhotosPage() {
                           src={photo.src}
                           alt={photo.alt}
                           loading="lazy"
-                          className={`w-full rounded-2xl object-cover transition ${
+                          className={`h-full w-full rounded-2xl object-cover transition ${
                             photo.blurred ? "blur-md" : ""
                           }`}
                         />
@@ -313,47 +311,39 @@ function PhotosPage() {
           </section>
         ))}
 
-        <section className="rounded-3xl border border-dashed border-neutral-200 bg-neutral-50 p-6">
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h3 className="text-lg font-semibold">Bulk upload</h3>
-              <p className="mt-1 text-sm text-neutral-500">
-                Upload multiple files into a selected album. Variants and
-                metadata are generated automatically.
-              </p>
+        {isAuthenticated ? (
+          <section className="rounded-3xl border border-dashed border-neutral-200 bg-neutral-50 p-6">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h3 className="text-lg font-semibold">Bulk upload</h3>
+                <p className="mt-1 text-sm text-neutral-500">
+                  Upload multiple files into a selected album. Variants and
+                  metadata are generated automatically.
+                </p>
+              </div>
             </div>
-            {!isAuthenticated ? (
-              <span className="text-xs font-semibold uppercase tracking-wide text-neutral-400">
-                Login required
-              </span>
-            ) : null}
-          </div>
-          <form className="mt-4 grid gap-4 md:grid-cols-[1fr_auto_auto]">
-            <select
-              disabled={!isAuthenticated}
-              className="rounded-2xl border border-neutral-200 bg-white px-4 py-2 text-sm text-neutral-600 disabled:cursor-not-allowed disabled:bg-neutral-100"
-            >
-              {albumOptions.map((album) => (
-                <option key={album.id} value={album.id}>
-                  {album.title}
-                </option>
-              ))}
-            </select>
-            <input
-              type="file"
-              multiple
-              disabled={!isAuthenticated}
-              className="rounded-2xl border border-neutral-200 bg-white px-4 py-2 text-sm text-neutral-600 file:mr-4 file:rounded-full file:border-0 file:bg-neutral-200 file:px-3 file:py-1 file:text-xs file:font-semibold file:uppercase file:text-neutral-700 disabled:cursor-not-allowed disabled:bg-neutral-100"
-            />
-            <button
-              type="button"
-              disabled={!isAuthenticated}
-              className="rounded-2xl bg-neutral-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white disabled:cursor-not-allowed disabled:bg-neutral-300"
-            >
-              Start upload
-            </button>
-          </form>
-        </section>
+            <form className="mt-4 grid gap-4 md:grid-cols-[1fr_auto_auto]">
+              <select className="rounded-2xl border border-neutral-200 bg-white px-4 py-2 text-sm text-neutral-600">
+                {albumOptions.map((album) => (
+                  <option key={album.id} value={album.id}>
+                    {album.title}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="file"
+                multiple
+                className="rounded-2xl border border-neutral-200 bg-white px-4 py-2 text-sm text-neutral-600 file:mr-4 file:rounded-full file:border-0 file:bg-neutral-200 file:px-3 file:py-1 file:text-xs file:font-semibold file:uppercase file:text-neutral-700"
+              />
+              <button
+                type="button"
+                className="rounded-2xl bg-neutral-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white"
+              >
+                Start upload
+              </button>
+            </form>
+          </section>
+        ) : null}
       </main>
 
       {slideshow && currentPhoto ? (

--- a/src/routes/photos/index.tsx
+++ b/src/routes/photos/index.tsx
@@ -1,0 +1,415 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useServerFn } from "@tanstack/react-start";
+import {
+  PHOTO_SESSION_COOKIE,
+  SESSION_MAX_AGE_SECONDS,
+  getPhotoLibrary,
+  loginToPhotoLibrary,
+  logoutFromPhotoLibrary,
+  type PhotoAlbum,
+} from "@/lib/photos.server";
+
+export const Route = createFileRoute("/photos/")({
+  component: PhotosPage,
+  loader: () => getPhotoLibrary(),
+  head: () => ({
+    meta: [
+      {
+        title: "photos – isak.dev",
+      },
+    ],
+  }),
+});
+
+type SlideshowState = {
+  album: PhotoAlbum;
+  index: number;
+  isPlaying: boolean;
+};
+
+function PhotosPage() {
+  const { categories, isAuthenticated } = Route.useLoaderData();
+  const login = useServerFn(loginToPhotoLibrary);
+  const logout = useServerFn(logoutFromPhotoLibrary);
+  const [password, setPassword] = useState("");
+  const [loginError, setLoginError] = useState<string | null>(null);
+  const [slideshow, setSlideshow] = useState<SlideshowState | null>(null);
+
+  const albumOptions = useMemo(
+    () =>
+      categories.flatMap((category) =>
+        category.albums.map((album) => ({
+          id: album.id,
+          title: album.title,
+        })),
+      ),
+    [categories],
+  );
+
+  const currentPhoto = useMemo(() => {
+    if (!slideshow) {
+      return null;
+    }
+    return slideshow.album.photos[slideshow.index] ?? null;
+  }, [slideshow]);
+
+  const startSlideshow = useCallback(
+    (album: PhotoAlbum) => {
+      if (!isAuthenticated) {
+        setLoginError("Log in to view the full-screen slideshow.");
+        return;
+      }
+      setSlideshow({ album, index: 0, isPlaying: true });
+    },
+    [isAuthenticated],
+  );
+
+  const nextSlide = useCallback(() => {
+    setSlideshow((current) => {
+      if (!current) {
+        return current;
+      }
+      const nextIndex = (current.index + 1) % current.album.photos.length;
+      return { ...current, index: nextIndex };
+    });
+  }, []);
+
+  const previousSlide = useCallback(() => {
+    setSlideshow((current) => {
+      if (!current) {
+        return current;
+      }
+      const previousIndex =
+        (current.index - 1 + current.album.photos.length) %
+        current.album.photos.length;
+      return { ...current, index: previousIndex };
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!slideshow || !slideshow.isPlaying) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      nextSlide();
+    }, 4000);
+
+    return () => window.clearInterval(timer);
+  }, [nextSlide, slideshow]);
+
+  useEffect(() => {
+    if (!slideshow) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setSlideshow(null);
+      }
+      if (event.key === "ArrowRight") {
+        nextSlide();
+      }
+      if (event.key === "ArrowLeft") {
+        previousSlide();
+      }
+      if (event.key === " ") {
+        setSlideshow((current) =>
+          current ? { ...current, isPlaying: !current.isPlaying } : current,
+        );
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [nextSlide, previousSlide, slideshow]);
+
+  const handleLogin = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoginError(null);
+
+    const result = await login({ data: { password } });
+
+    if (!result.ok || !result.token) {
+      setLoginError(result.message ?? "Unable to sign in.");
+      return;
+    }
+
+    document.cookie = `${PHOTO_SESSION_COOKIE}=${encodeURIComponent(
+      result.token,
+    )}; Max-Age=${result.maxAgeSeconds ?? SESSION_MAX_AGE_SECONDS}; Path=/; SameSite=Lax`;
+    window.location.reload();
+  };
+
+  const handleLogout = async () => {
+    await logout();
+    document.cookie = `${PHOTO_SESSION_COOKIE}=; Max-Age=0; Path=/; SameSite=Lax`;
+    window.location.reload();
+  };
+
+  return (
+    <div className="min-h-screen bg-white text-neutral-900">
+      <header className="sticky top-0 z-20 border-b border-neutral-200/70 bg-white/90 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <Link
+              to="/"
+              className="text-sm font-semibold uppercase tracking-widest text-neutral-400"
+            >
+              isak.dev
+            </Link>
+            <h1 className="mt-2 text-3xl font-semibold lowercase tracking-tight">
+              photos
+            </h1>
+            <p className="mt-1 text-sm text-neutral-500">
+              Private photo library. Public visitors only see blurred previews.
+            </p>
+          </div>
+
+          <div className="w-full md:w-auto">
+            {isAuthenticated ? (
+              <div className="flex flex-col items-start gap-2 rounded-2xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-sm">
+                <p className="font-medium text-neutral-700">
+                  Logged in — full-resolution access unlocked.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleLogout}
+                  className="rounded-full border border-neutral-300 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-neutral-700 transition hover:border-neutral-400"
+                >
+                  Log out
+                </button>
+              </div>
+            ) : (
+              <form
+                onSubmit={handleLogin}
+                className="flex w-full flex-col gap-3 rounded-2xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-sm md:w-80"
+              >
+                <label className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                  Enter password
+                </label>
+                <div className="flex flex-col gap-3 md:flex-row">
+                  <input
+                    type="password"
+                    name="password"
+                    value={password}
+                    onChange={(event) => setPassword(event.target.value)}
+                    placeholder="Photo library password"
+                    className="w-full rounded-full border border-neutral-200 px-4 py-2 text-sm text-neutral-700 outline-none transition focus:border-neutral-400"
+                  />
+                  <button
+                    type="submit"
+                    className="rounded-full bg-neutral-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white transition hover:bg-neutral-800"
+                  >
+                    Unlock
+                  </button>
+                </div>
+                {loginError ? (
+                  <p className="text-xs font-medium text-rose-600">
+                    {loginError}
+                  </p>
+                ) : null}
+              </form>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto flex max-w-6xl flex-col gap-16 px-6 py-12">
+        {categories.map((category) => (
+          <section key={category.id} className="space-y-8">
+            <div>
+              <h2 className="text-2xl font-semibold lowercase">
+                {category.title}
+              </h2>
+              {category.description ? (
+                <p className="mt-1 text-sm text-neutral-500">
+                  {category.description}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="space-y-12">
+              {category.albums.map((album) => (
+                <article
+                  key={album.id}
+                  className="rounded-3xl border border-neutral-200 bg-white p-6 shadow-sm"
+                >
+                  <div className="flex flex-col gap-6 lg:flex-row">
+                    <div className="relative w-full overflow-hidden rounded-2xl border border-neutral-100 lg:w-80">
+                      <img
+                        src={album.coverSrc}
+                        alt={`${album.title} cover`}
+                        className={`h-56 w-full object-cover transition ${
+                          album.coverBlurred ? "blur-md" : ""
+                        }`}
+                        loading="lazy"
+                      />
+                      {album.coverBlurred ? (
+                        <div className="absolute inset-0 rounded-2xl ring-1 ring-white/40" />
+                      ) : null}
+                    </div>
+
+                    <div className="flex flex-1 flex-col justify-between gap-4">
+                      <div>
+                        <div className="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-wide text-neutral-400">
+                          <span>{album.date}</span>
+                          <span>•</span>
+                          <span>{album.photoCount} photos</span>
+                        </div>
+                        <h3 className="mt-2 text-xl font-semibold">
+                          {album.title}
+                        </h3>
+                        {album.description ? (
+                          <p className="mt-2 text-sm text-neutral-500">
+                            {album.description}
+                          </p>
+                        ) : null}
+                      </div>
+
+                      <div className="flex flex-wrap items-center gap-3">
+                        <button
+                          type="button"
+                          onClick={() => startSlideshow(album)}
+                          className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-wide transition ${
+                            isAuthenticated
+                              ? "bg-neutral-900 text-white hover:bg-neutral-800"
+                              : "cursor-not-allowed border border-neutral-200 text-neutral-400"
+                          }`}
+                          disabled={!isAuthenticated}
+                        >
+                          Play slideshow
+                        </button>
+                        {!isAuthenticated ? (
+                          <span className="text-xs text-neutral-400">
+                            Sign in to watch the full-screen slideshow.
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="mt-6 columns-1 gap-4 sm:columns-2 lg:columns-3">
+                    {album.photos.map((photo) => (
+                      <figure
+                        key={photo.id}
+                        className="mb-4 break-inside-avoid overflow-hidden rounded-2xl"
+                      >
+                        <img
+                          src={photo.src}
+                          alt={photo.alt}
+                          loading="lazy"
+                          className={`w-full rounded-2xl object-cover transition ${
+                            photo.blurred ? "blur-md" : ""
+                          }`}
+                        />
+                      </figure>
+                    ))}
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
+        ))}
+
+        <section className="rounded-3xl border border-dashed border-neutral-200 bg-neutral-50 p-6">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h3 className="text-lg font-semibold">Bulk upload</h3>
+              <p className="mt-1 text-sm text-neutral-500">
+                Upload multiple files into a selected album. Variants and
+                metadata are generated automatically.
+              </p>
+            </div>
+            {!isAuthenticated ? (
+              <span className="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+                Login required
+              </span>
+            ) : null}
+          </div>
+          <form className="mt-4 grid gap-4 md:grid-cols-[1fr_auto_auto]">
+            <select
+              disabled={!isAuthenticated}
+              className="rounded-2xl border border-neutral-200 bg-white px-4 py-2 text-sm text-neutral-600 disabled:cursor-not-allowed disabled:bg-neutral-100"
+            >
+              {albumOptions.map((album) => (
+                <option key={album.id} value={album.id}>
+                  {album.title}
+                </option>
+              ))}
+            </select>
+            <input
+              type="file"
+              multiple
+              disabled={!isAuthenticated}
+              className="rounded-2xl border border-neutral-200 bg-white px-4 py-2 text-sm text-neutral-600 file:mr-4 file:rounded-full file:border-0 file:bg-neutral-200 file:px-3 file:py-1 file:text-xs file:font-semibold file:uppercase file:text-neutral-700 disabled:cursor-not-allowed disabled:bg-neutral-100"
+            />
+            <button
+              type="button"
+              disabled={!isAuthenticated}
+              className="rounded-2xl bg-neutral-900 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white disabled:cursor-not-allowed disabled:bg-neutral-300"
+            >
+              Start upload
+            </button>
+          </form>
+        </section>
+      </main>
+
+      {slideshow && currentPhoto ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-950/95 p-6 text-white">
+          <div className="absolute right-6 top-6 flex items-center gap-2 text-xs uppercase tracking-wide">
+            <span>
+              {slideshow.index + 1} / {slideshow.album.photos.length}
+            </span>
+            <span>•</span>
+            <span>{slideshow.album.title}</span>
+          </div>
+
+          <img
+            src={currentPhoto.src}
+            alt={currentPhoto.alt}
+            className="max-h-[80vh] w-auto rounded-2xl object-contain shadow-2xl"
+          />
+
+          <div className="absolute bottom-8 left-1/2 flex -translate-x-1/2 items-center gap-3">
+            <button
+              type="button"
+              onClick={previousSlide}
+              className="rounded-full border border-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-wide transition hover:border-white"
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setSlideshow((current) =>
+                  current
+                    ? { ...current, isPlaying: !current.isPlaying }
+                    : current,
+                )
+              }
+              className="rounded-full border border-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-wide transition hover:border-white"
+            >
+              {slideshow.isPlaying ? "Pause" : "Play"}
+            </button>
+            <button
+              type="button"
+              onClick={nextSlide}
+              className="rounded-full border border-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-wide transition hover:border-white"
+            >
+              Next
+            </button>
+            <button
+              type="button"
+              onClick={() => setSlideshow(null)}
+              className="rounded-full border border-white/40 px-4 py-2 text-xs font-semibold uppercase tracking-wide transition hover:border-white"
+            >
+              Exit
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a simple server-rendered photo gallery at `/photos` with public blurred previews and authenticated full-resolution access.
- Offer a minimal masonry gallery UI with albums, album metadata, and an old-school fullscreen slideshow play mode.

### Description
- Add `src/lib/photos.server.ts` which implements an in-memory photo library, password login (`loginToPhotoLibrary`), logout, server-side session token creation/verification, and server functions that return either blurred or full image URLs depending on auth state.
- Add `src/routes/photos/index.tsx` which registers a `/photos` page that loads `getPhotoLibrary()` server data, renders categories/albums/photos, includes a password login form, a bulk-upload placeholder UI, and a fullscreen auto-advancing slideshow with keyboard controls.
- Update `src/routeTree.gen.ts` to register the new `/photos` route so it is included in the app routing tree.

### Testing
- Started the dev server with `pnpm dev` (Vite) and confirmed it served the app successfully at port 4173.
- Ran a Playwright script that navigated to `http://127.0.0.1:4173/photos` and captured a screenshot of the page, which completed and produced an artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69884560da3c83299a0704d6840e588f)