### PR TITLE
Tighten mobile photos layout and remove /photos browser tint

### DIFF
--- a/src/routes/photos/index.tsx
+++ b/src/routes/photos/index.tsx
@@ -253,7 +253,7 @@ function PhotosPage() {
                       ) : null}
                     </div>
 
-                    <div className="flex flex-1 flex-col justify-between gap-4 px-4 pb-4 lg:px-6 lg:py-6">
+                  <div className="mt-4 columns-1 gap-4 px-4 pb-4 sm:columns-2 lg:columns-3 lg:px-6 lg:pb-6">
                       <div>
                         <div className="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-wide text-neutral-400">
                           <span>{album.date}</span>

--- a/src/routes/photos/index.tsx
+++ b/src/routes/photos/index.tsx
@@ -18,6 +18,10 @@ export const Route = createFileRoute("/photos/")({
       {
         title: "photos – isak.dev",
       },
+      {
+        name: "theme-color",
+        content: "#ffffff",
+      },
     ],
   }),
 });
@@ -151,7 +155,7 @@ function PhotosPage() {
   return (
     <div className="min-h-screen bg-white text-neutral-900">
       <header className="sticky top-0 z-20 border-b border-neutral-200/70 bg-white/90 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-6 md:flex-row md:items-center md:justify-between">
+        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 md:flex-row md:items-center md:justify-between md:px-6 md:py-6">
           <div>
             <Link
               to="/"
@@ -214,7 +218,7 @@ function PhotosPage() {
         </div>
       </header>
 
-      <main className="mx-auto flex max-w-6xl flex-col gap-16 px-6 py-12">
+      <main className="mx-auto flex max-w-6xl flex-col gap-12 px-4 py-8 md:gap-16 md:px-6 md:py-12">
         {categories.map((category) => (
           <section key={category.id} className="space-y-8">
             <div>
@@ -232,24 +236,24 @@ function PhotosPage() {
               {category.albums.map((album) => (
                 <article
                   key={album.id}
-                  className="rounded-3xl border border-neutral-200 bg-white p-6 shadow-sm"
+                  className="overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-sm"
                 >
                   <div className="flex flex-col gap-6 lg:flex-row">
-                    <div className="relative w-full overflow-hidden rounded-2xl border border-neutral-100 lg:w-80">
+                    <div className="relative aspect-[4/3] w-full overflow-hidden lg:aspect-auto lg:w-80 lg:self-stretch">
                       <img
                         src={album.coverSrc}
                         alt={`${album.title} cover`}
-                        className={`h-56 w-full object-cover transition ${
+                        className={`h-full w-full object-cover transition ${
                           album.coverBlurred ? "blur-md" : ""
                         }`}
                         loading="lazy"
                       />
                       {album.coverBlurred ? (
-                        <div className="absolute inset-0 rounded-2xl ring-1 ring-white/40" />
+                        <div className="absolute inset-0 ring-1 ring-white/40" />
                       ) : null}
                     </div>
 
-                    <div className="flex flex-1 flex-col justify-between gap-4">
+                    <div className="flex flex-1 flex-col justify-between gap-4 px-4 pb-4 lg:px-6 lg:py-6">
                       <div>
                         <div className="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-wide text-neutral-400">
                           <span>{album.date}</span>
@@ -288,7 +292,7 @@ function PhotosPage() {
                     </div>
                   </div>
 
-                  <div className="mt-6 columns-1 gap-4 sm:columns-2 lg:columns-3">
+                  <div className="columns-1 gap-4 px-4 pb-4 sm:columns-2 lg:columns-3 lg:px-6 lg:pb-6">
                     {album.photos.map((photo) => (
                       <figure
                         key={photo.id}
@@ -298,7 +302,7 @@ function PhotosPage() {
                           src={photo.src}
                           alt={photo.alt}
                           loading="lazy"
-                          className={`h-full w-full rounded-2xl object-cover transition ${
+                          className={`h-full w-full object-cover transition ${
                             photo.blurred ? "blur-md" : ""
                           }`}
                         />


### PR DESCRIPTION
### Motivation
- Reduce excessive padding on small screens for the `/photos` route so content feels tighter on mobile devices.
- Ensure album cover and gallery images fill their containers edge-to-edge using `object-cover` so photos reach the corners of their cards.
- Remove the blue browser UI tint on mobile when visiting `/photos` by providing a page-specific theme color.

### Description
- Added a `theme-color` meta tag (`#ffffff`) to the `/photos` route head to override the mobile browser tint in `src/routes/photos/index.tsx`.
- Tightened header and main spacing at small breakpoints by changing classes from `px-6 py-6`/`px-6 py-12` to smaller `px-4 py-4`/`px-4 py-8` and restored larger spacing with `md:` overrides in `src/routes/photos/index.tsx`.
- Made album cards `overflow-hidden` and removed the inner border/padding so cover images can run to card edges, and switched the cover wrapper to an `aspect-[4/3]` container with the cover `img` using `h-full w-full object-cover` in `src/routes/photos/index.tsx`.
- Adjusted gallery container padding and removed image-level rounding so images fill tiles while container clipping (`rounded-2xl`) preserves corner rounding, implemented in `src/routes/photos/index.tsx`.

### Testing
- Ran `pnpm build` which completed successfully (build artifacts generated) indicating the site builds with the change.
- Ran `pnpm check` which reported failures due to existing repository-wide Biome formatting/lint issues unrelated to these changes and pre-existing `document.cookie` lint warnings in this file, so lint/format did not pass here.
- Captured an automated mobile screenshot via Playwright of `http://127.0.0.1:3000/photos` to validate layout, saved at `browser:/tmp/codex_browser_invocations/dc7602c905214b99/artifacts/artifacts/photos-mobile.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ae585138c8329bd7202bf1981af96)